### PR TITLE
docs: fixup default s3 creds

### DIFF
--- a/docs/helm-charts.md
+++ b/docs/helm-charts.md
@@ -106,6 +106,24 @@ secretKey:
 
 The chart then computes a random alphanumeric string of 32 characters
 for the field(s).
+The generated values are printed to the console after the installation completes
+successfully. They can also be retrieved later.
+
+To obtain the access key:
+
+```bash
+kubectl --namespace $S3GW_NAMESPACE get secret \
+  $(yq .defaultUserCredentialSecret values.yaml) \
+  -o yaml | yq .data.RGW_DEFAULT_USER_ACCESS_KEY | base64 -d
+```
+
+and to obtain the secret key:
+
+```bash
+kubectl --namespace $S3GW_NAMESPACE get secret \
+  $(yq .defaultUserCredentialSecret values.yaml) \
+  -o yaml | yq .data.RGW_DEFAULT_USER_SECRET_KEY | base64 -d
+```
 
 - **Existing secret**
 


### PR DESCRIPTION
Add information on how to obtain the randomly generated access key and secret key, should the user not have provided them.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
